### PR TITLE
fix: handle binary files like png

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -45,7 +45,7 @@ wss.on('connection', (ws) => {
     const res = responses.get(id);
     if (res) {
       res.writeHead(statusCode, headers);
-      res.end(body);
+      res.end(Buffer.from(body, 'base64url'));
       responses.delete(id);
     }
   });
@@ -77,7 +77,7 @@ const server = http.createServer((req, res) => {
     method: req.method,
     url: req.url,
     headers: req.headers as Record<string, string>,
-    body: Buffer.concat(chunks).toString('utf8'),
+    body: Buffer.concat(chunks).toString('base64url'),
   } satisfies TunnelRequest)));
 });
 

--- a/src/vgrok.ts
+++ b/src/vgrok.ts
@@ -155,13 +155,13 @@ async function main() {
           id,
           statusCode: res.statusCode ?? 999,
           headers: res.headers as Record<string, string>,
-          body: Buffer.concat(chunks).toString('utf8')
+          body: Buffer.concat(chunks).toString('base64url')
         } satisfies TunnelResponse));
       });
     });
   
     if (body) {
-      req.write(body);
+      req.write(Buffer.from(body, 'base64url'));
     }
     req.end();
   });


### PR DESCRIPTION
We can't use utf8 for binary files like png so instead we use base64. And we can use base64url which tends to be a few bytes smaller.